### PR TITLE
Master

### DIFF
--- a/Resources/Constants.py
+++ b/Resources/Constants.py
@@ -17,7 +17,8 @@ SPEAKER_RADIUS = 15
 #TYPE = "A" 
 
 # Liste pour le l'utilisateur
-SPEAKERS_SETUP_LIST = ["", "Stereo", "Quad", "Octo-Left-Right", "Octo-Front-Back"] # JR 23 mai 2017
+SPEAKERS_SETUP_LIST = ["Stereo", "Quad", "Octo-Left-Right", "Octo-Front-Back"] # FL 26/05/17
+#SPEAKERS_SETUP_LIST = ["", "Stereo", "Quad", "Octo-Left-Right", "Octo-Front-Back"] # JR 23 mai 2017
 
 
 SETUP_STEREO = [(100, 100), (500, 100)]

--- a/Resources/MainFrame.py
+++ b/Resources/MainFrame.py
@@ -139,7 +139,7 @@ class MyFrame(wx.Frame):
         audio = vars.getVars("Audio")
         audio.server.stop()
 #        server.stop() #JR 20 mai
-        print "Cleaning up..."
+#        print "Cleaning up..." FL 26/05/17
         # FL - START 22/05/17 
         try:
             self.Destroy()
@@ -148,9 +148,13 @@ class MyFrame(wx.Frame):
         raise SystemExit
         # FL - END 22/05/17
 
+    # FL 26/05/17 
+    # Le problème des zones de Speakers commence ici... je n'arrive pas à trouver où et quand est défini "Speakers", défini dans le fichier 
+    # "Variables". Le problème part peut-être de là? As-tu supprimé par erreur l'initialisation de cette variable?
     def radiusZone(self,e):
         x = e.value
         speakers = vars.getVars("Speakers")
+        print str(len(speakers))
         for i in range(len(speakers)):
             speakers[i].setZoneRad(x)
         self.surface.Refresh()

--- a/Resources/Pref.py
+++ b/Resources/Pref.py
@@ -14,11 +14,13 @@ class PrefDlg(wx.Dialog):
 #        self.panel = wx.Panel(self)
         sizer = wx.BoxSizer(wx.VERTICAL)
 
-        self.nchnlsLabel = wx.StaticText(self, -1, "Nchnls")
+        self.nchnlsLabel = wx.StaticText(self, -1, "Number of channels (Audio File)")
+#        self.nchnlsLabel = wx.StaticText(self, -1, "Nchnls")
         self.nchnlsChoices = wx.Choice(self, choices = NCHNLS_LIST)
         self.numSpkLabel = wx.StaticText(self, -1, "Speakers Setup")
         self.numSpkChoices = wx.Choice(self, choices = SPEAKERS_SETUP_LIST)
-        self.OSCPortLabel = wx.StaticText(self, -1, "OSC Port")
+        self.OSCPortLabel = wx.StaticText(self, -1, "OSC Input Port") # Fl 26/05/17   
+#        self.OSCPortLabel = wx.StaticText(self, -1, "OSC Input Port") # FL 26/05/17
         self.OSCPortText = wx.TextCtrl(self, -1, "%s" % pref["OSCPORT"], size=(80,20))
         sizer.Add(self.nchnlsLabel, 0, wx.TOP|wx.LEFT, 5)
         sizer.Add(self.nchnlsChoices, 1, wx.BOTTOM|wx.LEFT, 5)
@@ -54,25 +56,52 @@ class PrefDlg(wx.Dialog):
         pref["NCHNLS"] = int(self.nchnlsChoices.GetStringSelection())
         print pref
         
-        
+        # FL START 26/05/17  
     def onNumSpk(self,e):
         pref["SPEAKERS_SETUP"] = self.numSpkChoices.GetSelection()
-        if pref["SPEAKERS_SETUP"] == 1:
+        if pref["SPEAKERS_SETUP"] == 0:
             vars.setVars("Speakers_setup", SETUP_STEREO)
             pref["NUM_SPEAKERS"] = len(SETUP_STEREO)
-        elif pref["SPEAKERS_SETUP"] == 2:
+        elif pref["SPEAKERS_SETUP"] == 1:
             vars.setVars("Speakers_setup", SETUP_QUAD)
             pref["NUM_SPEAKERS"] = len(SETUP_QUAD)
-        elif pref["SPEAKERS_SETUP"] == 3:
+        elif pref["SPEAKERS_SETUP"] == 2:
             vars.setVars("Speakers_setup", SETUP_OCTO_STEREO)
             pref["NUM_SPEAKERS"] = len(SETUP_OCTO_STEREO)
-        elif pref["SPEAKERS_SETUP"] == 4:
+        elif pref["SPEAKERS_SETUP"] == 3:
             vars.setVars("Speakers_setup", SETUP_OCTO_DIAMAND)
             pref["NUM_SPEAKERS"] = len(SETUP_OCTO_DIAMAND)
         else:
             pass
         print pref
+#         def onNumSpk(self,e):
+#        pref["SPEAKERS_SETUP"] = self.numSpkChoices.GetSelection()
+#        if pref["SPEAKERS_SETUP"] == 1:
+#            vars.setVars("Speakers_setup", SETUP_STEREO)
+#            pref["NUM_SPEAKERS"] = len(SETUP_STEREO)
+#        elif pref["SPEAKERS_SETUP"] == 2:
+#            vars.setVars("Speakers_setup", SETUP_QUAD)
+#            pref["NUM_SPEAKERS"] = len(SETUP_QUAD)
+#        elif pref["SPEAKERS_SETUP"] == 3:
+#            vars.setVars("Speakers_setup", SETUP_OCTO_STEREO)
+#            pref["NUM_SPEAKERS"] = len(SETUP_OCTO_STEREO)
+#        elif pref["SPEAKERS_SETUP"] == 4:
+#            vars.setVars("Speakers_setup", SETUP_OCTO_DIAMAND)
+#            pref["NUM_SPEAKERS"] = len(SETUP_OCTO_DIAMAND)
+#        else:
+#            pass
+#        print pref
+        # FL END 26/05/17
         
     def setOSC(self):
         pref["OSCPORT"] = self.OSCPortText.GetValue()
+        
+    # FL START 26/05/17
+    # Cette fonction permet aux préférences de se mettre à jour même si on ne les a pas changées dans la fenêtre de configuration initiale.
+    def commitPrefs(self):
+        self.onNchnls(None)
+        self.onNumSpk(None)
+        self.setOSC()
+    # FL END 26/05/17
+        
             

--- a/SpatialTool.py
+++ b/SpatialTool.py
@@ -13,21 +13,30 @@ class MyApp(wx.App):
     def OnInit(self):
         # Start JR 23 mai 2017
         dlg = PrefDlg()
+        dlg.CenterOnScreen() # FL 26/05/2017
         if dlg.ShowModal() == wx.ID_OK:
-            dlg.Destroy()
+            # FL START 26/05/17
+            dlg.commitPrefs()
+            audio = Audio()
+            vars.setVars("Audio", audio)
+            oscServer = OSCServer()   #JR 21 mai
+            vars.setVars("OSCServer", oscServer)   # JR 21 mai
+            frame = MyFrame()
+            vars.setVars("MainFrame", frame)
+            self.SetTopWindow(frame)
+            frame.Show()
+            return True
+#            dlg.Destroy()
+            # FL END 26/05/17
         else:
-            dlg.Destroy()
+            try: #FL 26/05/17
+                dlg.Destroy()
+            except: #FL 26/05/17
+                pass #FL 26/05/17
+        raise SystemExit #FL 26/05/17
         # End JR 23 mai 2017
 
-        audio = Audio()
-        vars.setVars("Audio", audio)
-        oscServer = OSCServer()   #JR 21 mai
-        vars.setVars("OSCServer", oscServer)   # JR 21 mai
-        frame = MyFrame()
-        vars.setVars("MainFrame", frame)
-        self.SetTopWindow(frame)
-        frame.Show()
-        return True
+        
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
- Correction de l’appel de la boite de préférences dans SpatialTool.py.

- Correction du bug qui faisait en sorte que l’on était obligé de les
choisir individuellement pour que l’application démarre. 

- Suppression du choix « vide » dans la préférence du « Speaker setup »… le choix vide par défaut ne faisait pas vraiment de sens…

- Tentative de
régler le problème des zones de speakers qui n’agrandissent plus… (voir
commentaire dans MainFrame.py). Pas réussi encore, à suivre…